### PR TITLE
Fix for SMS and incoming calls on Xperia with KitKat 4.4.4

### DIFF
--- a/app/src/main/java/com/althink/android/ossw/notifications/parser/BaseNotificationParser.java
+++ b/app/src/main/java/com/althink/android/ossw/notifications/parser/BaseNotificationParser.java
@@ -101,7 +101,7 @@ public class BaseNotificationParser {
     }
 
 
-    private boolean isFlagSet(android.app.Notification notification, int flag) {
+    protected boolean isFlagSet(android.app.Notification notification, int flag) {
         return (notification.flags & flag) != 0;
     }
 

--- a/app/src/main/java/com/althink/android/ossw/notifications/parser/BaseNotificationParser.java
+++ b/app/src/main/java/com/althink/android/ossw/notifications/parser/BaseNotificationParser.java
@@ -76,7 +76,8 @@ public class BaseNotificationParser {
     }
 
     protected boolean isValidAlert(StatusBarNotification sbn) {
-        if ("com.android.dialer".equals(sbn.getPackageName()) || "com.android.phone".equals(sbn.getPackageName())) {
+        if ("com.android.dialer".equals(sbn.getPackageName()) || "com.android.phone".equals(sbn.getPackageName()) 
+                || "com.android.incallui".equals(sbn.getPackageName())) {
             return true;
         }
         if (hasActions(sbn)) {
@@ -93,7 +94,7 @@ public class BaseNotificationParser {
     @TargetApi(19)
     private boolean hasActions(StatusBarNotification sbn) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-            if (sbn.getNotification().actions.length > 0) {
+            if (sbn.getNotification().actions != null && sbn.getNotification().actions.length > 0) {
                 return true;
             }
         }
@@ -170,7 +171,8 @@ public class BaseNotificationParser {
     }
 
     protected NotificationType getNotificationType(StatusBarNotification sbn, Notification existingNotification) {
-        if ("com.android.dialer".equals(sbn.getPackageName()) && existingNotification != null) {
+        if (("com.android.dialer".equals(sbn.getPackageName()) || "com.android.incallui".equals(sbn.getPackageName())) 
+                && existingNotification != null) {
             return sbn.getNotification().priority > 0 ? NotificationType.ALERT : NotificationType.INFO;
         }
         if ("com.htc.android.worldclock".equals(sbn.getPackageName()) && hasActions(sbn)) {

--- a/app/src/main/java/com/althink/android/ossw/notifications/parser/api19/NotificationParserApi19.java
+++ b/app/src/main/java/com/althink/android/ossw/notifications/parser/api19/NotificationParserApi19.java
@@ -56,7 +56,8 @@ public class NotificationParserApi19 extends BaseNotificationParser {
         NotificationType type = getNotificationType(sbn, existingNotification);
         Date date = new Date(sbn.getNotification().when);
 
-        if (NotificationType.INFO == type && sbn.getNotification().deleteIntent == null) {
+        if (NotificationType.INFO == type 
+                && isFlagSet(sbn.getNotification(), android.app.Notification.FLAG_ONGOING_EVENT)) {
             Log.i(TAG, "SKIP NON REMOVABLE NOTIFICATION");
             return null;
         }


### PR DESCRIPTION
It's my first pull request in here. Hope I did everything well :)

I've been testing this for a few days. Works stable for me.

Most interesting point is change in NotificationParserApi19 from checking for `deleteIntent == null` to checking if `Notification.FLAG_ONGOING_EVENT` is set. According to developer's documentation, deleteIntent is executed when notification is being dismissed by the user - it's a hook. But I've found out that it's not good to detect non-removable notifications. It may be null for normal removable notifications too (eg. my SMS notifications).
The ongoing event flag seems to work ok. It fixed not only SMS but other useful notifications like jakdojade.pl (public transport navigation) - now the watch again can remind me to get off at the right bus stop :)

Other changes (for incoming calls) are simply additional checks for `com.android.incallui` instead of just `com.android.dialer` (I don't get these on my phone), and one null check to prevent exception when `Notification.actions` is null.
